### PR TITLE
Rebuild jinja2-time 0.2.0 for python 3.10 support

### DIFF
--- a/recipe/0000-replace-replace-shift.patch
+++ b/recipe/0000-replace-replace-shift.patch
@@ -1,0 +1,11 @@
+--- jinja2_time/jinja2_time.py	2022-03-08 08:19:07.405491468 -0600
++++ jinja2_time/jinja2_time.py	2022-03-08 08:19:23.217557370 -0600
+@@ -23,7 +23,7 @@
+         for param in offset.split(','):
+             interval, value = param.split('=')
+             replace_params[interval.strip()] = float(operator + value.strip())
+-        d = d.replace(**replace_params)
++        d = d.shift(**replace_params)
+ 
+         if datetime_format is None:
+             datetime_format = self.environment.datetime_format

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,40 +10,46 @@ source:
   fn: {{ gh_repo }}-{{ version }}.tar.gz
   url: https://github.com/{{ gh_org }}/{{ gh_repo }}/archive/{{ version }}.tar.gz
   sha256: 0e647e525ba47523fa400a58fdec090b1cc6dcec4afbf095ee01e9e589e5a5ef
+  patches:
+    # remove after https://github.com/hackebrot/jinja2-time/pull/19 (or similar)
+    - 0000-replace-replace-shift.patch
 
 build:
   noarch: python
-  number: 2
+  number: 3
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   host:
+    - m2-patch  # [win]
+    - patch     # [not win]
     - pip
     - python
     - setuptools
+    - wheel
   run:
-    # Using arrow >=0.15.6 causes `test_add_time`, `test_substract_time`, and
-    # `test_offset_with_format` to fail with AttribuetErrors; arrow 0.13.1 is
-    # known to work, and compatibility with arrow 0.14.x is unknown.  We don't
-    # provide arrow=0.14, so we'll leave the pinning at <0.15 until we have
-    # evidence to do otherwise.
-    - arrow <0.15
+    - arrow
     - jinja2
     - python
 
 test:
+  imports:
+    - jinja2_time
   source_files:
-    - .
+    - tests
   requires:
     - freezegun
-    - pytest
-    - python
+    - pip
+    - pytest-cov
   commands:
-    - py.test
+    - pip check
+    - cd tests && pytest -vv --cov jinja2_time --cov-report term-missing:skip-covered --no-cov-on-fail --cov-fail-under 100
 
 about:
   home: https://github.com/{{ gh_org }}/{{ gh_repo }}
   license: MIT
+  license_family: MIT
+  license_file: LICENSE
   summary: Jinja2 Extension for Dates and Times
 
 extra:


### PR DESCRIPTION
Changelog: https://github.com/hackebrot/jinja2-time/releases
License: https://github.com/hackebrot/jinja2-time/blob/0.2.0/LICENSE
Requirements: https://github.com/hackebrot/jinja2-time/blob/0.2.0/setup.py

Actions:
1. Add 0000-replace-replace-shift.patch
2. Bump build number to 3
3. Add (m2)-patch
4. Add missing wheel
5. Remove pinning for arrow
6. Add imports
7. Update tests
8. Add license_family
9. Add license_file